### PR TITLE
Make sure taht the python installation is correct and remove useless project files

### DIFF
--- a/Numpy.NET.sln
+++ b/Numpy.NET.sln
@@ -5,20 +5,6 @@ VisualStudioVersion = 15.0.28307.645
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Numpy", "src\Numpy\Numpy.csproj", "{D527C885-AD64-4499-9E92-F9A543C0D14B}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Numpy.UnitTest", "test\Numpy.UnitTest\Numpy.UnitTest.csproj", "{1B69F24E-8C60-421D-B11B-5306ED7A060E}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{25D84E98-E107-45C9-A0EC-0B25E24DA607}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MatmulExample", "src\Examples\MatmulExample\MatmulExample.csproj", "{A92C1287-BF2B-4FDC-8BBA-A17F410CD41F}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Numpy.Bare", "src\Numpy.Bare\Numpy.Bare.csproj", "{DA501219-D114-4ED1-9B34-C39CC0480D04}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Numpy.Bare.UnitTest", "test\Numpy.UnitTest\Numpy.Bare.UnitTest.csproj", "{3E69A902-0C8F-4FF4-BA27-EAB9D2E08FEA}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReleaseBot", "src\ReleaseBot\ReleaseBot.csproj", "{2BAEA60C-88A2-45DC-8044-2C9571E1B8CF}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NeuralNetworkExample", "NeuralNetworkExample\NeuralNetworkExample.csproj", "{66A030C3-69B8-4A84-9F4B-308D66CF4FD3}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,37 +15,9 @@ Global
 		{D527C885-AD64-4499-9E92-F9A543C0D14B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D527C885-AD64-4499-9E92-F9A543C0D14B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D527C885-AD64-4499-9E92-F9A543C0D14B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1B69F24E-8C60-421D-B11B-5306ED7A060E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1B69F24E-8C60-421D-B11B-5306ED7A060E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1B69F24E-8C60-421D-B11B-5306ED7A060E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1B69F24E-8C60-421D-B11B-5306ED7A060E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A92C1287-BF2B-4FDC-8BBA-A17F410CD41F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A92C1287-BF2B-4FDC-8BBA-A17F410CD41F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A92C1287-BF2B-4FDC-8BBA-A17F410CD41F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A92C1287-BF2B-4FDC-8BBA-A17F410CD41F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DA501219-D114-4ED1-9B34-C39CC0480D04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DA501219-D114-4ED1-9B34-C39CC0480D04}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DA501219-D114-4ED1-9B34-C39CC0480D04}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DA501219-D114-4ED1-9B34-C39CC0480D04}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3E69A902-0C8F-4FF4-BA27-EAB9D2E08FEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3E69A902-0C8F-4FF4-BA27-EAB9D2E08FEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3E69A902-0C8F-4FF4-BA27-EAB9D2E08FEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3E69A902-0C8F-4FF4-BA27-EAB9D2E08FEA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2BAEA60C-88A2-45DC-8044-2C9571E1B8CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2BAEA60C-88A2-45DC-8044-2C9571E1B8CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2BAEA60C-88A2-45DC-8044-2C9571E1B8CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2BAEA60C-88A2-45DC-8044-2C9571E1B8CF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{66A030C3-69B8-4A84-9F4B-308D66CF4FD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{66A030C3-69B8-4A84-9F4B-308D66CF4FD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{66A030C3-69B8-4A84-9F4B-308D66CF4FD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{66A030C3-69B8-4A84-9F4B-308D66CF4FD3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{A92C1287-BF2B-4FDC-8BBA-A17F410CD41F} = {25D84E98-E107-45C9-A0EC-0B25E24DA607}
-		{66A030C3-69B8-4A84-9F4B-308D66CF4FD3} = {25D84E98-E107-45C9-A0EC-0B25E24DA607}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5EB08541-5168-443C-B524-A5CB7E7C613D}

--- a/src/Numpy/Numpy.csproj
+++ b/src/Numpy/Numpy.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/epignatelli/Numpy.NET</RepositoryUrl>
     <PackageTags>Data science, Machine Learning, ML, AI, Scientific Computing, NumPy, Linear Algebra, FFT, SVD, Matrix, Python</PackageTags>
     <PackageLicenseUrl></PackageLicenseUrl>
-    <Version>3.7.1.15-alpha</Version>
+    <Version>3.7.1.16-alpha</Version>
     <PackageIconUrl></PackageIconUrl>
     <Company>bhom.xyz</Company>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BH.UI.Python.Included" Version="3.7.3.6-alpha" />
+    <PackageReference Include="BH.UI.Python.Included" Version="3.7.3.7-alpha" />
     <PackageReference Include="BH.UI.Python.Runtime" Version="3.7.2-alpha" />
     <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
   </ItemGroup>


### PR DESCRIPTION
Closes #1 
Closes #2 

The Python.Included that was used was not deleting the `._pth` file correctly, making the python installation to fail.